### PR TITLE
Función para nuevo gráfico

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .Ruserdata
+rmd_files

--- a/R/grafico_cedula.R
+++ b/R/grafico_cedula.R
@@ -1,0 +1,43 @@
+# definiendo df de diseño
+df = tribble(
+   ~label_partido, ~x1, ~x2, ~y1, ~y2, ~y_partido,
+       "Partido1",   7,   8,   7,   8,        7.5,
+       "Partido2",   7,   8,   5,   6,        5.5,
+       "Partido3",   7,   8,   3,   4,        3.5,
+       "Partido4",   7,   8,   1,   2,        1.5)
+
+grafico_cedula <- function(.df, filtrar = NULL){
+  
+  # diseño base
+  plot <- ggplot(.df)+
+    # rectangulos de voto preferencial
+    geom_rect(aes(xmin = x1, xmax = x2, ymin = y1, ymax = y2), color = "black", fill = "white")+
+    geom_rect(aes(xmin = x1 +1, xmax = x2+1, ymin = y1, ymax = y2), color = "black", fill = "white") +
+    # delimitando tamaño de  marco contenedor
+    xlim(c(0, 10)) +
+    ylim(c(0, 10)) +
+    # nombre de partido
+    geom_text(aes(x = 1, y = y_partido, label = label_partido), hjust = 0) +
+    # titulo de cedula
+    geom_text(aes(x = 5, y = 9.5, label = "CEDULA")) +
+    # marco negro de contenedor, alpha es 0 para lograr transparencia
+    geom_rect(aes(xmin = 0, xmax = 10, ymin = 0, ymax = 10), color = "black", alpha = 0)
+  
+    # se filtra la data y se cubren los partidos que no pasan los filtros
+    if(!is.null(filtrar)){
+      filtrado <- filter(.df, !(label_partido %in% filtrar))
+      plot <- plot + geom_rect(data = filtrado, aes(xmin = 0.5, xmax = 9.5, ymin = y1-0.5, ymax = y2+0.5))
+    }
+    # se retorna plot y se elimina el plano cartesiano
+    plot +
+      theme_void()
+}
+
+# sólo cédula
+grafico_cedula(df)  
+
+# un partido filtrado
+grafico_cedula(df, "Partido2")
+
+# varios filtrados
+grafico_cedula(df, c("Partido1", "Partido3"))

--- a/src/ggraficoresumen.R
+++ b/src/ggraficoresumen.R
@@ -13,11 +13,10 @@ ggraficoresumen <- function(variable, resumen){
     labs(title=strtitle, x="Partido", y = strylabel) +
     coord_flip() +
     theme_minimal() +
-    geom_text(aes(x = Partido, 
-                  y = !!rlang::sym(variable) - 0.5, 
-                  label = !!rlang::sym(variable), 
-                  hjust = 1), 
-              color = "#FFFFFF")+
+    geom_label(aes(label = !!rlang::sym(variable), 
+                  hjust = 1),
+                  size = 3,
+                  label.padding = unit(0.15, "lines"))+
     annotate("text", x = c(5.5, 11, 16.5), y = max(resumen[[variable]])/2, label = "www.decidebien.pe",
              hjust=0.5, vjust=0.5, col="red", cex=6,
              fontface = "bold", alpha = 0.2)  


### PR DESCRIPTION
# grafico_cedula
Nueva función `grafico_cedula()` para asemejar filtrado con cedula real. Un df con posiciones nos ayuda a diseñar:
```r
# definiendo df de diseño
df = tribble(
   ~label_partido, ~x1, ~x2, ~y1, ~y2, ~y_partido,
       "Partido1",   7,   8,   7,   8,        7.5,
       "Partido2",   7,   8,   5,   6,        5.5,
       "Partido3",   7,   8,   3,   4,        3.5,
       "Partido4",   7,   8,   1,   2,        1.5)
```
```r
# sólo cédula
grafico_cedula(df) 
```
![image](https://user-images.githubusercontent.com/19418298/71146181-313b6600-21f2-11ea-9796-35ad93d5e65e.png)

```r
# un partido filtrado
grafico_cedula(df, "Partido2")
```
![image](https://user-images.githubusercontent.com/19418298/71146204-4adcad80-21f2-11ea-9408-8bbbb1a9541b.png)

```r
# varios filtrados
grafico_cedula(df, c("Partido1", "Partido3"))
```
![image](https://user-images.githubusercontent.com/19418298/71146218-59c36000-21f2-11ea-8276-063ae5b981e9.png)
